### PR TITLE
Change bill imports to billing

### DIFF
--- a/src/billing_calculator_hep/AWSBillAnalysis.py
+++ b/src/billing_calculator_hep/AWSBillAnalysis.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 import logging
 import sys
 import traceback
-import bill_calculator_hep.graphite
+import billing_calculator_hep.graphite
 #import graphite
 import configparser
 import yaml

--- a/src/billing_calculator_hep/GCEBillAnalysis.py
+++ b/src/billing_calculator_hep/GCEBillAnalysis.py
@@ -2,7 +2,7 @@ import json
 import boto
 import gcs_oauth2_boto_plugin
 
-import bill_calculator_hep.graphite
+import billing_calculator_hep.graphite
 import logging
 
 import csv


### PR DESCRIPTION
After renaming the module from **bill_calculator_hep** to **billing_calculator_hep**, we need to update the imports accordingly.