### PR TITLE
Fix case sensitivity of unBlendedCost field name in AWS billing

### DIFF
--- a/src/bill_calculator_hep/AWSBillAnalysis.py
+++ b/src/bill_calculator_hep/AWSBillAnalysis.py
@@ -318,7 +318,7 @@ class AWSBillCalculator(object):
         totalDataOutCsvHeaderString = 'TotalDataOut'
         estimatedTotalDataOutCsvHeaderString = 'EstimatedTotalDataOut'
         usageQuantityHeaderString = 'UsageQuantity'
-        unBlendedCostCsvHeaderString = 'UnBlendedCost'
+        unBlendedCostCsvHeaderString = 'UnblendedCost'
         usageStartDateCsvHeaderString = 'UsageStartDate'
         totalCsvHeaderString = 'Total'
 


### PR DESCRIPTION
The changes coming from this PR fixes hepcloud/decisionengine_modules#504.



### Investigation notes
- The `UnBlendedCost` field was something present in the header of the billing files. When I initially checked on cmssrvz07 much before reproducing this issue on my dev environment, this error seemed to be happening because the field (specifically case sensitivity of the name) was not the case in the most recent billing files for 2025 when compared to the same field name in billing files for 2023
- After my dev environment was setup to reproduce the same error as Steve’s reported issue (using a much latest date in 2024), I closely looked back in time across billing files in 2024 that were downloaded. First, inspected Jan, Jun and Dec 2024 billing files in `~/aws_config/awsfiles` which were downloaded when the source ran. All of them had `UnblendedCost` as the field name. Second, ensured that Jan and Feb 2025 billing files also had the same field name, which was the case. This made me wonder if things changed sometime in 2023, which caused the field name (specifically, case sensitivity) to change which might have been hard to recognize if it did happen
- Next, I checked Jan, Jun and Dec 2023 billing files from cmssrvz07 to my dev environment to inspect the files. Noticed that Jan and Jun 2023 billing files had `UnBlendedCost` (and `UnBlendedRate`) fields (with `B` as opposed to `b`). But Dec 2023 billing files had lowercase `b` , which matched what was observed in 2024 and 2025 billing files
- Next, I checked Sept 2023 billing file from cmssrvz07 to my dev environment to inspect the file. This also had lowercase `b`
- Further, checked Jul and Aug 2023 billing files from cmssrvz07 to my dev environment to inspect the file. This also had lowercase `b`
- These inspection steps revealed that since Jul 2023, the field(s) `UnblendedCost` (and `UnblendedRate` in the header of the billing files were using lowercase `b` instead of the previous format which used uppercase `B` as was seen in billing files until Jun 2023 (inclusive).
- With that confirmed, checked `AWSBillAnalysis.py` to see if the field was defined using uppercase `B` and it was the case. Changed the name defined to use lowercase `b` and restarted DE and the error no longer occurs, thus addressing the problem reported.