### PR TITLE
Include added support for pandas as part of `google-cloud-bigquery` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author="Maria P. Acosta F./HEPCloud project",
     author_email="macosta@fnal.gov",
     description="Billing calculations and threshold alarms for hybrid cloud setups",
-    install_requires=['gcs_oauth2_boto_plugin', 'pyparsing', 'google-cloud-bigquery', 'google-cloud-bigquery[pandas]'],
+    install_requires=['gcs_oauth2_boto_plugin', 'pyparsing', 'google-cloud-bigquery[pandas]'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author="Maria P. Acosta F./HEPCloud project",
     author_email="macosta@fnal.gov",
     description="Billing calculations and threshold alarms for hybrid cloud setups",
-    install_requires=['gcs_oauth2_boto_plugin', 'pyparsing', 'google-cloud-bigquery'],
+    install_requires=['gcs_oauth2_boto_plugin', 'pyparsing', 'google-cloud-bigquery', 'google-cloud-bigquery[pandas]'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',


### PR DESCRIPTION
During Vito's testing of HEPCloud DE 2.0.5 with `bill-calculator-hep 0.2.`, the following error stacktrace was reported in Decision Engine's `resource_request.log`:

```
Traceback (most recent call last):
  File "/home/decisionengine/.local/lib/python3.9/site-packages/decisionengine/framework/taskmanager/TaskManager.py", line 297, in decision_cycle
    actions = self.run_logic_engine(data_block_t1)
  File "/home/decisionengine/.local/lib/python3.9/site-packages/decisionengine/framework/taskmanager/TaskManager.py", line 377, in run_logic_engine
    actions, new_facts = self.logic_engine.module_instance.evaluate(data_block)
  File "/home/decisionengine/.local/lib/python3.9/site-packages/decisionengine/framework/logicengine/LogicEngine.py", line 79, in evaluate
    evaluated_facts = self.evaluate_facts(db)
  File "/home/decisionengine/.local/lib/python3.9/site-packages/decisionengine/framework/logicengine/LogicEngine.py", line 67, in evaluate_facts
    raise e
  File "/home/decisionengine/.local/lib/python3.9/site-packages/decisionengine/framework/logicengine/LogicEngine.py", line 54, in evaluate_facts
    return {name: f.evaluate(db) for name, f in self.facts.items()}
  File "/home/decisionengine/.local/lib/python3.9/site-packages/decisionengine/framework/logicengine/LogicEngine.py", line 54, in <dictcomp>
    return {name: f.evaluate(db) for name, f in self.facts.items()}
  File "/home/decisionengine/.local/lib/python3.9/site-packages/decisionengine/framework/logicengine/BooleanExpression.py", line 84, in evaluate
    return bool(eval(self.expr, _facts_globals, d))
  File "string", line 1, in <module>
  File "/usr/local/lib64/python3.9/site-packages/pandas/core/indexing.py", line 1073, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "/usr/local/lib64/python3.9/site-packages/pandas/core/indexing.py", line 1625, in _getitem_axis
    self._validate_integer(key, axis)
  File "/usr/local/lib64/python3.9/site-packages/pandas/core/indexing.py", line 1557, in _validate_integer
    raise IndexError("single positional indexer is out-of-bounds")
IndexError: single positional indexer is out-of-bounds
```

Upon investigation by Vito, turns out there was a missing dependency `db-dtypes` for `google-cloud-bigquery`.  To install `db-dtypes`, it is required to install `google-cloud-bigquery[pandas]`. Checking `setup.py` for `bill-calculator-hep`, `google-cloud-bigquery` is already included and it was the added support for pandas that was missing in the list of dependencies. (More information about what the square brackets mean following the library name is explained [here](https://stackoverflow.com/questions/46775346/what-do-square-brackets-mean-in-pip-install))